### PR TITLE
Remove ER diagram from generated code

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,6 @@ Create a file in your repo in which you hand-write documentation for your schema
 For example, `docs/db-schema.md`:
 
 ```
-# Database Schema
-
-The Entity Relationship representation:
-
-<<<-ERDIAGRAM->>>
 
 # Database tables
 
@@ -25,18 +20,10 @@ The `Users` table stores user records.
 <<<-Users->>>
 ```
 
-This action will replace the placeholder `<<<-ERDIAGRAM->>>` with an image to a generated ER diagram.
-
-It will also replace all occurrences of `<<<-Users->>>` with a markdown table that describes the structure of the database table identified by what is in between `<<<-` and `->>>`. In the above example, the generated documentation would look like this:
+This action will replace all occurrences of `<<<-Users->>>` with a markdown table that describes the structure of the database table identified by what is in between `<<<-` and `->>>`. In the above example, the generated documentation would look like this:
 
 
 ```markdown
-# Database Schema
-
-The Entity Relationship representation:
-
-![](/docs/images/schema.png)
-
 # Database tables
 
 ## Users table
@@ -78,12 +65,6 @@ The following tables have not been documented. Please document them if needed.
 ```
 
 ## Inputs
-
-### PATH_TO_ER_DIAGRAM
-
-Path to store the ER Diagram image relative the project root directory.
-
-**Required**
 
 ### PATH_TO_DB_SCHEMA_FILE
 
@@ -168,7 +149,6 @@ jobs:
       - name: Generate database schema
         uses:  gps/document-postgres-schema@master
         with:
-          PATH_TO_ER_DIAGRAM: "docs/images/schema.png"
           PATH_TO_DB_SCHEMA_FILE: "docs/db-schema.md"
           PATH_TO_GENERATED_DB_SCHEMA_FILE: "docs/generated-db-schema.md"
           DATABASE_USER_NAME: "foobar"

--- a/action.yml
+++ b/action.yml
@@ -2,9 +2,6 @@ name: "Generate PostgreSQL Schema Documentation"
 description: "Generates database schema documentation for a PostgreSQL Database"
 author: "Kumar M Shrivatsav <kumar.sm@surya-soft.com>"
 inputs:
-  PATH_TO_ER_DIAGRAM:
-    description: Path to store the ER Diagram image relative the project root directory.
-    required: true
   PATH_TO_DB_SCHEMA_FILE:
     description: Path to hand written db schema documentation file relative the project root directory.
     required: true

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -12,7 +12,4 @@ echo "Script executed"
 echo "Format generated markdown file"
 /node_modules/prettier/bin-prettier.js --write "${INPUT_PATH_TO_GENERATED_DB_SCHEMA_FILE}"
 
-echo "Copying generated schema image from /tmp/tbls/doc/schema/ to path specified"
-cp "/tmp/tbls/doc/schema/schema.png" "/github/workspace/${INPUT_PATH_TO_ER_DIAGRAM}"
-
 echo "Schema Document successfully generated"

--- a/generate_db_schema_documentation.py
+++ b/generate_db_schema_documentation.py
@@ -72,7 +72,7 @@ def get_table(filename):
         table_file_read = table_file.read()
         table_file_read_split_columns = table_file_read.split("## Columns")
         table_file_read_tables = table_file_read_split_columns[1]
-        tables = table_file_read_tables.split("## Relations\n")
+        tables = table_file_read_tables.split("---\n")
         table = tables[0]
         return filter_table(table)
 

--- a/generate_db_schema_documentation.py
+++ b/generate_db_schema_documentation.py
@@ -108,7 +108,7 @@ def main():
                         generated_db_schema.writelines("\n")
 
             except Exception as e:
-                print(e)
+                print("Database schema generation failed due to error:",e)
                 sys.exit(1)
         generate_table_of_contents()
     finally:

--- a/generate_db_schema_documentation.py
+++ b/generate_db_schema_documentation.py
@@ -6,12 +6,12 @@ from os import listdir
 import os
 import re
 import subprocess
+import sys
 
 PATH_TO_TEMP_FOLDER = "/tmp/tbls/doc/schema/"
 PATH_TO_GITHUB_WORKSPACE = "/github/workspace/"
 DATABASE_TABLE_PREFIX = "public."
 FILE_EXTENSION = ".md"
-INPUT_PATH_TO_ER_DIAGRAM = os.environ["INPUT_PATH_TO_ER_DIAGRAM"]
 PATH_TO_DB_SCHEMA_FILE = os.environ["INPUT_PATH_TO_DB_SCHEMA_FILE"]
 PATH_TO_GENERATED_DB_SCHEMA_FILE = os.environ["INPUT_PATH_TO_GENERATED_DB_SCHEMA_FILE"]
 INPUT_DATABASE_HOST = os.environ["INPUT_DATABASE_HOST"]
@@ -19,12 +19,10 @@ INPUT_DATABASE_NAME = os.environ["INPUT_DATABASE_NAME"]
 INPUT_DATABASE_PASSWORD = os.environ["INPUT_DATABASE_PASSWORD"]
 INPUT_DATABASE_PORT = os.environ["INPUT_DATABASE_PORT"]
 INPUT_DATABASE_USER_NAME = os.environ["INPUT_DATABASE_USER_NAME"]
-ER_DIAGRAM_KEY = "ERDIAGRAM"
 TBLS_YML = f"""
 dsn: postgres://{INPUT_DATABASE_USER_NAME}:{INPUT_DATABASE_PASSWORD}@{INPUT_DATABASE_HOST}:{INPUT_DATABASE_PORT}/{INPUT_DATABASE_NAME}?sslmode=disable
 er:
-  format: png
-  distance: 2
+  skip: true
 exclude:
   - public.flyway_schema_history
 
@@ -79,10 +77,7 @@ def get_table(filename):
         return filter_table(table)
 
 def get_replace_line(key):
-    if(key == ER_DIAGRAM_KEY):
-        return f"![](/{INPUT_PATH_TO_ER_DIAGRAM})"
-    else:
-        return get_table(key)
+    return get_table(key)
 
 def main():
     try: 
@@ -114,6 +109,7 @@ def main():
 
             except Exception as e:
                 print(e)
+                sys.exit(1)
         generate_table_of_contents()
     finally:
         delete_tbls_yml()


### PR DESCRIPTION
- The generated ER diagram is not readable. hence, it is decided to remove it. 
- Mark github action as failure in case of Failure. 