### PR TITLE
Set WorkDirectory to /usr/app [WIP]

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,11 @@ COPY package-lock.json /package-lock.json
 # NPM needs this
 ENV CI=true
 
-RUN chmod +x /entrypoint.sh && \
-    chmod +x /generate_db_schema_documentation.py && \
+COPY ./ /usr/app
+WORKDIR /usr/app
+
+RUN chmod +x entrypoint.sh && \
+    chmod +x generate_db_schema_documentation.py && \
     pip3 install -r requirements.txt && \
     npm install
 


### PR DESCRIPTION
The Action fails with the following bug:
```
npm ERR! Tracker "idealTree" already exists
```

This is caused because the latest Docker [container](https://hub.docker.com/r/nikolaik/python-nodejs) uses Node 16.x

This fix is highlighted [here](https://stackoverflow.com/a/65443098/16358020)