### PR TITLE
Use Nodejs14 Container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM nikolaik/python-nodejs
+FROM nikolaik/python-nodejs:python3.10-nodejs14
 
 COPY entrypoint.sh /entrypoint.sh
 COPY requirements.txt /requirements.txt


### PR DESCRIPTION
The Action fails with the following bug:
```
npm ERR! Tracker "idealTree" already exists
```

This is caused because the latest Docker [container](https://hub.docker.com/r/nikolaik/python-nodejs) uses Node 16.x

This fix is highlighted [here](https://stackoverflow.com/a/65443098/16358020)

Currently Fixing it by downgrading to Nodejs14 as the fix does not seem to be working for this `nikolaik/python-nodejs` container.